### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ bower_components
 build/Release
 
 # Dependency directories
+
 node_modules/
 jspm_packages/
 


### PR DESCRIPTION
# ¿Que ha cambiado?
Agregamos el gitignore soporte para node

- [ ] FrontEnd
- [ ] BackEnd
- [X] Server Settings.

# Como pudo probar los cambios?
Los archivos y la carpeta node.module ya no se suben al repo, ver el archivo gitignore completo
